### PR TITLE
Add NLTK VADER sentiment pipeline and reusable Amazon scraper

### DIFF
--- a/scraper_amazon/amazon_requests_scraper.py
+++ b/scraper_amazon/amazon_requests_scraper.py
@@ -1,34 +1,59 @@
+import re
+from typing import List, Optional
+
 import requests
 from bs4 import BeautifulSoup
-import pandas as pd
 
-headers = {"User-Agent": "Mozilla/5.0"}
 
-data = []
+HEADERS = {"User-Agent": "Mozilla/5.0"}
+AMAZON_SEARCH_URL = "https://www.amazon.in/s"
 
-for page in range(1,6):
 
-    url = f"https://www.amazon.in/s?k=headphones&page={page}"
-    response = requests.get(url, headers=headers)
+def _extract_reviews_from_html(html: str) -> List[str]:
+    """Extract review snippets from Amazon search-result HTML."""
+    soup = BeautifulSoup(html, "lxml")
+    review_nodes = soup.select("span.a-size-base.s-underline-text")
 
-    soup = BeautifulSoup(response.content, "lxml")
+    reviews: List[str] = []
+    for node in review_nodes:
+        text = re.sub(r"\s+", " ", node.get_text(strip=True))
+        if text:
+            reviews.append(text)
 
-    items = soup.select(".s-result-item")
+    return reviews
 
-    for item in items:
 
-        name = item.select_one(".a-size-medium.a-color-base.a-text-normal")
-        price = item.select_one(".a-price-whole")
-        rating = item.select_one(".a-icon-alt")
+def get_amazon_reviews(
+    query: str = "headphones",
+    pages: int = 5,
+    timeout: int = 15,
+    session: Optional[requests.Session] = None,
+) -> List[str]:
+    """
+    Scrape Amazon pages and return a list of extracted review snippets.
 
-        name = name.text if name else "N/A"
-        price = price.text if price else "N/A"
-        rating = rating.text if rating else "N/A"
+    Args:
+        query: Search keyword used for product discovery.
+        pages: Number of pages to scrape.
+        timeout: HTTP timeout in seconds.
+        session: Optional requests Session for reuse/testing.
+    """
+    client = session or requests.Session()
+    reviews: List[str] = []
 
-        data.append([name, price, rating])
+    for page in range(1, pages + 1):
+        response = client.get(
+            AMAZON_SEARCH_URL,
+            params={"k": query, "page": page},
+            headers=HEADERS,
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        reviews.extend(_extract_reviews_from_html(response.text))
 
-df = pd.DataFrame(data, columns=["Product","Price","Rating"])
+    return reviews
 
-df.to_csv("amazon_products.csv", index=False)
 
-print(df.head())
+if __name__ == "__main__":
+    scraped_reviews = get_amazon_reviews()
+    print(f"Scraped {len(scraped_reviews)} review snippets.")

--- a/sentiment/__init__.py
+++ b/sentiment/__init__.py
@@ -1,0 +1,1 @@
+"""Sentiment analysis package."""

--- a/sentiment/sentiment_analyzer.py
+++ b/sentiment/sentiment_analyzer.py
@@ -1,0 +1,65 @@
+import json
+import re
+import string
+from typing import Dict, List
+
+import nltk
+from nltk.sentiment import SentimentIntensityAnalyzer
+
+from scraper_amazon.amazon_requests_scraper import get_amazon_reviews
+
+
+def _ensure_vader_lexicon() -> None:
+    """Ensure the VADER lexicon is available in the runtime environment."""
+    try:
+        nltk.data.find("sentiment/vader_lexicon.zip")
+    except LookupError:
+        nltk.download("vader_lexicon", quiet=True)
+
+
+def preprocess_text(text: str) -> str:
+    """Normalize text by lowercasing and removing punctuation."""
+    lowered = text.lower()
+    no_punctuation = lowered.translate(str.maketrans("", "", string.punctuation))
+    return re.sub(r"\s+", " ", no_punctuation).strip()
+
+
+def classify_sentiment(score: float) -> str:
+    """Classify sentiment label from VADER compound score."""
+    if score >= 0.05:
+        return "positive"
+    if score <= -0.05:
+        return "negative"
+    return "neutral"
+
+
+def analyze_amazon_reviews() -> Dict[str, object]:
+    """
+    Fetch reviews from scraper and return aggregate + detailed sentiment output.
+    """
+    _ensure_vader_lexicon()
+    reviews = get_amazon_reviews()
+    analyzer = SentimentIntensityAnalyzer()
+
+    results: List[Dict[str, str]] = []
+    summary = {"positive": 0, "negative": 0, "neutral": 0}
+
+    for review in reviews:
+        cleaned_review = preprocess_text(review)
+        score = analyzer.polarity_scores(cleaned_review)["compound"]
+        sentiment = classify_sentiment(score)
+        summary[sentiment] += 1
+        results.append({"review": review, "sentiment": sentiment})
+
+    return {
+        "total_reviews": len(reviews),
+        "positive": summary["positive"],
+        "negative": summary["negative"],
+        "neutral": summary["neutral"],
+        "detailed_results": results,
+    }
+
+
+if __name__ == "__main__":
+    result = analyze_amazon_reviews()
+    print(json.dumps(result, indent=2))


### PR DESCRIPTION
### Motivation
- Provide a production-ready sentiment analysis pipeline that imports live reviews from the existing scraper rather than using hardcoded/sample data. 
- Make the sentiment analyzer importable by backend code using a clear API and avoid scraper side effects at import time. 

### Description
- Refactored `scraper_amazon/amazon_requests_scraper.py` to expose `get_amazon_reviews(query: str = "headphones", pages: int = 5, ...) -> List[str]` and removed import-time scraping side effects. 
- Added `sentiment/sentiment_analyzer.py` which imports `get_amazon_reviews`, preprocesses text (lowercase + remove punctuation), ensures the NLTK VADER lexicon is available, scores text with `SentimentIntensityAnalyzer`, classifies by compound score using thresholds `>=0.05` (positive) and `<=-0.05` (negative), and returns the requested JSON structure from `analyze_amazon_reviews()`. 
- Added `sentiment/__init__.py` so the analyzer can be imported as `from sentiment.sentiment_analyzer import analyze_amazon_reviews`. 
- Each module uses a main guard (`if __name__ == "__main__"`) to allow safe imports and a simple CLI trigger that runs the pipeline and prints JSON. 

### Testing
- Compiled modules with `python -m py_compile scraper_amazon/amazon_requests_scraper.py sentiment/sentiment_analyzer.py sentiment/__init__.py`, and compilation succeeded. 
- Attempted a small runtime import and function check with `python - <<'PY' ... PY'`, but it failed due to the runtime environment missing the `nltk` package; this is an environment dependency and not a code syntax issue. 
- The analyzer includes runtime logic to download the VADER lexicon if missing (`nltk.download("vader_lexicon")`), so installing `nltk` in the environment is required for end-to-end execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b19e0150c4832c8333da319c402771)