### PR TITLE
Harden Amazon scraper with resilient fallback reviews

### DIFF
--- a/scraper_amazon/amazon_requests_scraper.py
+++ b/scraper_amazon/amazon_requests_scraper.py
@@ -7,8 +7,22 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 
-HEADERS = {"User-Agent": "Mozilla/5.0"}
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/123.0.0.0 Safari/537.36"
+    ),
+    "Accept-Language": "en-US,en;q=0.9",
+}
 AMAZON_SEARCH_URL = "https://www.amazon.in/s"
+FALLBACK_REVIEWS = [
+    "Great product and good sound quality",
+    "Very bad battery life",
+    "Average performance but acceptable",
+    "Worth the price",
+    "Poor build quality",
+]
 
 
 def _extract_reviews_from_html(html: str) -> List[str]:
@@ -25,31 +39,54 @@ def _extract_reviews_from_html(html: str) -> List[str]:
     return reviews
 
 
-def get_amazon_reviews() -> List[str]:
-    """Scrape Amazon pages and return a list of extracted review snippets."""
+def _fallback_reviews(reason: str) -> List[str]:
+    """Return local fallback reviews when scraping fails."""
+    print(f"Warning: {reason}. Falling back to local reviews.")
+    return FALLBACK_REVIEWS.copy()
+
+
+def _build_retry_session() -> requests.Session:
+    """Create a requests session configured with retry behavior."""
     session = requests.Session()
-    retry = Retry(total=3, backoff_factor=1, status_forcelist=[429, 500, 502, 503, 504])
+    retry = Retry(
+        total=3,
+        connect=3,
+        read=3,
+        backoff_factor=1,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=["GET"],
+    )
     adapter = HTTPAdapter(max_retries=retry)
     session.mount("http://", adapter)
     session.mount("https://", adapter)
+    return session
 
-    reviews: List[str] = []
 
-    for page in range(1, 6):
-        response = session.get(
-            AMAZON_SEARCH_URL,
-            params={"k": "headphones", "page": page},
-            headers=HEADERS,
-            timeout=15,
-        )
+def get_amazon_reviews() -> List[str]:
+    """Scrape Amazon pages and always return a list of review strings."""
+    try:
+        session = _build_retry_session()
+        reviews: List[str] = []
 
-        if response.status_code != 200:
-            print(f"Warning: Amazon returned status {response.status_code}")
-            return []
+        for page in range(1, 6):
+            response = session.get(
+                AMAZON_SEARCH_URL,
+                params={"k": "headphones", "page": page},
+                headers=HEADERS,
+                timeout=15,
+            )
 
-        reviews.extend(_extract_reviews_from_html(response.text))
+            if response.status_code != 200:
+                return _fallback_reviews(f"Amazon returned status {response.status_code}")
 
-    return reviews
+            reviews.extend(_extract_reviews_from_html(response.text))
+
+        if not reviews:
+            return _fallback_reviews("No reviews found in scraped HTML")
+
+        return [str(review) for review in reviews if isinstance(review, str) and review.strip()]
+    except Exception as exc:  # noqa: BLE001 - scraper must never crash the pipeline.
+        return _fallback_reviews(f"Amazon scraping failed with error: {exc}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Amazon often returns HTTP 503 / blocks scraper requests which can cause the sentiment pipeline to crash or return no data.
- Ensure `get_amazon_reviews()` never raises and always returns a `List[str]` so downstream sentiment analysis continues to work.
- Preserve the module import path and `if __name__ == "__main__"` behavior so other modules can use the function unchanged.

### Description
- Added richer browser-like `HEADERS` and a `FALLBACK_REVIEWS` constant containing local review strings used when scraping fails.
- Introduced `_build_retry_session()` to centralize `requests` retry configuration and `_fallback_reviews(reason)` to print a warning and return a copy of the fallback list.
- Refactored `get_amazon_reviews()` to use the retry session, handle non-200 responses and empty parse results by returning fallbacks, and catch all exceptions so it never crashes the pipeline.
- Kept import compatibility (`from scraper_amazon.amazon_requests_scraper import get_amazon_reviews`) and the existing main guard that prints the returned list when executed as a script.

### Testing
- Ran an automated smoke test that attempted to import and call `get_amazon_reviews()` which failed at runtime due to the execution environment missing the `requests` package (raised `ModuleNotFoundError: No module named 'requests'`).
- No unit tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1a5299154832cb0a1671a1ab57a78)